### PR TITLE
specify step 3 is only for X11

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Side note: Please make sure to incorporate fallback fonts and address other nece
 </fontconfig>
 ```
 
-### Step 3
+### Step 3 (Only for X11)
 
 Install xorg-xrdb (if needed).
 


### PR DESCRIPTION
So less experienced user know this step doesn't apply if they're on wayland, and doesn't create useless configurations file like ~/.Xauthority